### PR TITLE
Refactored to use a seperate emails array & Promise.allSettled

### DIFF
--- a/api/emaily.js
+++ b/api/emaily.js
@@ -6,6 +6,14 @@ const mg = mailgun({
   domain: 'hackclub.com'
 });
 
+// TODO: Split into .JSON file and parsed
+const emails = [
+  "abby@hackclub.com",
+  "max@hackclub.com",
+  "christina@hackclub.com",
+  "sam@hackclub.com"
+]
+
 export default (req, res) => {
   if (req.query.date) {
     fetch('https://bank.hackclub.com/api/v3/organizations/hq/transactions')
@@ -50,10 +58,11 @@ export default (req, res) => {
         <th style="padding: 3px 0px;">Amount</th>
       </tr>${txs2}</table><br />${endingMessage}`;
 
-        await sendEmail('abby@hackclub.com', 'abby@hackclub.com', subject, html);
-        await sendEmail('max@hackclub.com', 'abby@hackclub.com', subject, html);
-        await sendEmail('christina@hackclub.com', 'abby@hackclub.com', subject, html);
-        await sendEmail('sam@hackclub.com', 'abby@hackclub.com', subject, html);
+        const emailPromises = emails.map((address) => sendEmail(address, 'abby@hackclub.com', subject, html))
+
+        const sent = await Promise.allSettled(emailPromises)
+
+        sent.ForEach((val,i) => val == "rejected" ? console.error(`Unable to send digest to ${emails[i]}`) : continue)
 
         res.status(200).send("it sent!!!! WOOOHOOOO");
       })

--- a/api/emaily.js
+++ b/api/emaily.js
@@ -62,7 +62,7 @@ export default (req, res) => {
 
         const sent = await Promise.allSettled(emailPromises)
 
-        sent.ForEach((val,i) => val.status == "rejected" ? console.error(`Unable to send digest to ${emails[i]}`) : continue)
+        sent.forEach((val,i) => val.status == "rejected" ? console.error(`Unable to send digest to ${emails[i]}`) : null)
 
         res.status(200).send("it sent!!!! WOOOHOOOO");
       })
@@ -87,9 +87,10 @@ function sendEmail(to, from, subject, html) {
     mg.messages().send(data, (error, body) => {
       if (error) {
         reject(error);
+      } else {
+        console.log("sent!");
+        resolve(body);
       }
-      console.log("sent!");
-      resolve(body);
     });
   });
 }

--- a/api/emaily.js
+++ b/api/emaily.js
@@ -62,7 +62,7 @@ export default (req, res) => {
 
         const sent = await Promise.allSettled(emailPromises)
 
-        sent.ForEach((val,i) => val == "rejected" ? console.error(`Unable to send digest to ${emails[i]}`) : continue)
+        sent.ForEach((val,i) => val.status == "rejected" ? console.error(`Unable to send digest to ${emails[i]}`) : continue)
 
         res.status(200).send("it sent!!!! WOOOHOOOO");
       })


### PR DESCRIPTION
I refactored emaily.js to use Promise.allSettled to send out the emails; that way they are sent concurrently & the whole system doesn't collapse if one email doesn't send. I also split email addresses into their own array, which enables you to pull them from a JSON file in the future.